### PR TITLE
nickname refers to login instead of mail

### DIFF
--- a/lib/omniauth/strategies/redmine.rb
+++ b/lib/omniauth/strategies/redmine.rb
@@ -17,7 +17,7 @@ module OmniAuth
 
       info do
         {
-          'nickname' => raw_info['user']['mail'],
+          'nickname' => raw_info['user']['login'],
           'email' => raw_info['user']['mail'],
           'name' => "#{raw_info['user']['lastname']} #{raw_info['user']['firstname']}"
         }


### PR DESCRIPTION
Gitlab7.5 stableで利用させていただこうと思ったところ、
GitLabのUsernameではメールアドレスフォーマットが禁止されていました。
そのため、nicknameにはRedmine側のmailではなくloginから取得するようにしてみました。

よろしければ変更受け入れよろしくお願いします。
